### PR TITLE
black for lines, box as single Shape, back visible

### DIFF
--- a/src/plot/x3d-plot.js
+++ b/src/plot/x3d-plot.js
@@ -203,8 +203,14 @@ ${x3d}`;
   var script = config.viewer === 'x3dom' ?
 `<script src="https://www.x3dom.org/download/x3dom.js"></script>` :
 `<script src="https://code.create3000.de/x_ite/4.6.9/dist/x_ite.min.js"></script>
-<script src="https://raw.githack.com/andreasplesch/x_ite_dom/master/release/x_ite_dom.1.3.js"></script>`;
-
+<script src="https://raw.githack.com/andreasplesch/x_ite_dom/master/release/x_ite_dom.1.3.js"></script>
+<script>
+//disable straighten horizon
+X3D ( function ready () {
+  var browser = X3D .getBrowser ("X3DCanvas");
+  browser .setBrowserOption('StraightenHorizon', false);
+});
+</script>`;
   var html = `
 <html>
 <head>

--- a/src/plot/x3d-plot.js
+++ b/src/plot/x3d-plot.js
@@ -108,13 +108,13 @@ function x3dPlot( id, data, config ) {
            orientation="${cr[1].join(' ')} ${cr[0]}"
            centerOfRotation="${xMid} ${yMid} ${zMid}"></Viewpoint>`;
 
-  if ( frame ) boxHelper.forEach( a =>
-    x3d += `
+  if ( frame ) x3d += `
 <Shape>
-<LineSet>
-<Coordinate point="${a[0].join(' ')} ${a[1].join(' ')}"></Coordinate>
+<Appearance><Material emissiveColor='0 0 0'></Material></Appearance>
+<LineSet vertexCount='2 2 2 2 2 2 2 2 2 2 2 2'>
+<Coordinate point="${boxHelper.map(a => a[0].concat(a[1]).join(' ')).join(',')}"></Coordinate>
 </LineSet>
-</Shape>` );
+</Shape>`;
 
   for ( var i = 0 ; i < surfaces.length ; i++ ) {
 
@@ -156,7 +156,7 @@ function x3dPlot( id, data, config ) {
 <Appearance>
 <TwoSidedMaterial diffuseColor="${color}" transparency="${1-s.options.opacity}"></TwoSidedMaterial>
 </Appearance>
-<IndexedFaceSet creaseAngle="1.57" coordIndex="${indices}">
+<IndexedFaceSet creaseAngle="1.57" solid='false' coordIndex="${indices}">
 <Coordinate point="${points}"></Coordinate>`;
 
     if ( 'colors' in s.options ) {


### PR DESCRIPTION
x_ite needs a Material; it is a bit more efficient to use a single Shape for the box, for both x3dom and x_ite; solid='false' switches on the back faces (x_ite is more strict here).