### PR TITLE
Support for setting options.translation.step = 0

### DIFF
--- a/src/render/threejs-template.js
+++ b/src/render/threejs-template.js
@@ -418,7 +418,7 @@ function addSurface( s ) {
 
   if ( s.options.translation ) {
     var arg = s.options.translation.argument ? s.options.translation.argument : 't';
-    var step = s.options.translation.step ? s.options.translation.step : .05;
+    var step = Number.isFinite(s.options.translation.step) ? s.options.translation.step : .05;
     mesh.userData.translation = { 
       path: Function( arg, 'return ' + s.options.translation.path ),
       step: step, t: 0 };


### PR DESCRIPTION
Per issue #30, uses Number.isFinite() to allow for setting translation.step to 0.